### PR TITLE
Fix UTXO fetching

### DIFF
--- a/css/multisig.css
+++ b/css/multisig.css
@@ -112,6 +112,11 @@ textarea, input[type="text"], input[type="number"], input[type="password"] {
   width: 300px;
   margin-top: 10px;
 }
+.selected_addresses {
+  display: block;
+  width: 600px;
+  margin-top: 10px;
+}
 .fees input {
   width: 100px;
 }

--- a/index.html
+++ b/index.html
@@ -73,6 +73,10 @@
           <label>What would you like the fee to be</label>
           <input type="text" class="miner_fee" placeholder="Enter miner fees">
         </div>
+        <div class="selected_addresses_div">
+          <label>What addresses should be redeemed ? (comma separated, no space)</label>
+          <input type="text" class="selected_addresses" placeholder="Enter addresses (example : 3P3P5o5EZUSutfmScksMVg8LBuEWpACpzX)">
+        </div>
         <footer>
           <button>Continue</button>
         </footer>

--- a/lib/multisig/address.js
+++ b/lib/multisig/address.js
@@ -99,14 +99,15 @@ Address.prototype = {
     this.fetched = true;
 
     if (!response) return;
-    if (response.length < 1) return;
+    if (!response.txrefs) return;
+    if (response.txrefs.length < 1) return;
 
-    this.unspentOutputs = response.map(function(output) {
+    this.unspentOutputs = response.txrefs.map(function(output) {
       return {
-        hash: output.txid,
-        index: output.vout,
-        amount: output.satoshis,
-        script: Bitcoin.Script.fromHex(output.scriptPubKey)
+        hash: output.tx_hash,
+        index: output.tx_output_n,
+        amount: output.value,
+        script: Bitcoin.Script.fromHex(output.script)
       }
     });
 

--- a/lib/multisig/constants.js
+++ b/lib/multisig/constants.js
@@ -4,7 +4,7 @@ var constants = {
   M: 2,
   MINIMUM_MINER_FEE: 20000,
   BITCOIN_SATOSHIS: 100000000,
-  INSIGHT_API_URL_ROOT: "https://insight.bitpay.com/api/",
+  BLOCKCYPHER_API_URL_ROOT: "https://api.blockcypher.com/v1/btc/main/",
   DEBUG: false,
   REQUEST_PIPELINE_SIZE: 2,
   REQUEST_BACKOFF: 250,

--- a/lib/multisig/insight.js
+++ b/lib/multisig/insight.js
@@ -13,7 +13,7 @@ let processTimeout;
 ***/
 var Insight = {
   getUnspentOutputs: function(address) {
-    return Insight.get("addr/" + address + "/utxo");
+    return Insight.get("addrs/" + address + "?unspentOnly=true&includeScript=true");
   },
   get: function(url) {
     // We need to return a promise
@@ -54,7 +54,7 @@ var Insight = {
     req.requestedTimes = req.requestedTimes + 1;
 
     // Fetch Insight API
-    $.get(constants.INSIGHT_API_URL_ROOT + req.url)
+    $.get(constants.BLOCKCYPHER_API_URL_ROOT + req.url)
     .done(function(res) {
       // Resolve outer promise
       req.resolve(res);

--- a/lib/multisig/vault.js
+++ b/lib/multisig/vault.js
@@ -100,7 +100,7 @@ Vault.prototype = {
   },
   buildTransaction: function(options) {
     this.tx = new Transaction({
-      addresses: this.addresses,
+      addresses: this.addresses.filter(address => options.selectedAddresses.includes(address.address)),
       minerFee: options.minerFee,
       destinationAddress: options.destinationAddress,
       seeds: {

--- a/lib/tool.js
+++ b/lib/tool.js
@@ -117,6 +117,7 @@ $(function() {
 
     vault.buildTransaction({
       minerFee: $('.miner_fee').val(),
+      selectedAddresses: $('.selected_addresses').val().split(','),
       destinationAddress: destinationAddress,
       seeds: {
         shared: sharedKeyInput,


### PR DESCRIPTION
The Bitpay insight API used by the original tool is not available anymore.

This fork intends to make the minimum required changes to make the tool functional again using the BlockCypher API.
It also allows you to pick which addresses you want to redeem, in case you don't want to withdraw everything from the vault.